### PR TITLE
OSOE-641: Fix remaining issues for the Orchard Core 1.6 upgrade in Orchard-Content-Editors

### DIFF
--- a/Lombiq.ContentEditors.Tests.UI/Lombiq.ContentEditors.Tests.UI.csproj
+++ b/Lombiq.ContentEditors.Tests.UI/Lombiq.ContentEditors.Tests.UI.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(NuGetBuild)' == 'true'">
-    <PackageReference Include="Lombiq.Tests.UI" Version="6.0.2-alpha.2.osoe-548" />
+    <PackageReference Include="Lombiq.Tests.UI" Version="6.0.2-alpha.1.osoe-641" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.ContentEditors/Lombiq.ContentEditors.csproj
+++ b/Lombiq.ContentEditors/Lombiq.ContentEditors.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(NuGetBuild)' == 'true'">
-    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="5.1.3-alpha.1.osoe-548" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="5.1.3-alpha.3.osoe-641" />
     <PackageReference Include="Lombiq.NodeJs.Extensions" Version="1.2.4-alpha.0.osoe-548" />
   </ItemGroup>
 


### PR DESCRIPTION
[OSOE-641](https://lombiq.atlassian.net/browse/OSOE-641)

[OSOE-641]: https://lombiq.atlassian.net/browse/OSOE-641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ